### PR TITLE
removed UTF8 BOMs

### DIFF
--- a/_main.cfg
+++ b/_main.cfg
@@ -1,4 +1,4 @@
-﻿#textdomain wesnoth-OrociaRandomMod
+#textdomain wesnoth-OrociaRandomMod
 [textdomain]
 	name="wesnoth-OrociaRandomMod"
 	path="data/add-ons/OrociaRandomMod/translations/"

--- a/scenarios/OrociaRandomMod.cfg
+++ b/scenarios/OrociaRandomMod.cfg
@@ -1,4 +1,4 @@
-﻿#textdomain wesnoth-OrociaRandomMod
+#textdomain wesnoth-OrociaRandomMod
 
 [multiplayer]
 	id=Orocia_Random_Ageless_Mod


### PR DESCRIPTION
For the sole purpuse of getting rid of this messages in stderr:
20170301 00:23:20 error config: Skipping over a utf8 BOM at ~add-ons/OrociaRandomMod/_main.cfg:1
20170301 00:23:20 error config: Skipping over a utf8 BOM at ~add-ons/OrociaRandomMod/scenarios/OrociaRandomMod.cfg:1
